### PR TITLE
fix: restore changelog history, dedupe header, never push to main

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -57,7 +57,9 @@ export default function(eleventyConfig) {
   // moved into the content tree.
   eleventyConfig.addGlobalData('changelog', () => {
     try {
-      return fs.readFileSync('./CHANGELOG.md', 'utf8')
+      // Strip the leading "# Changelog" line — src/changelog.njk
+      // renders its own <h1>, so keeping this would duplicate it.
+      return fs.readFileSync('./CHANGELOG.md', 'utf8').replace(/^#\s+Changelog\s*\n+/, '')
     } catch {
       return '_No releases yet._'
     }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,13 @@ here so there's one place to keep in sync.
 An [Eleventy](https://11ty.dev) (v3) static site for msb.fyi, deployed to
 Cloudflare Pages on push to `main` (`.github/workflows/publish.yml`).
 
+## Never push directly to `main`
+
+Every change, no matter how small, goes through a branch and a PR — even a
+one-line doc fix. Before running `git push`, check
+`git branch --show-current`; if it's `main`, stop and create a branch
+first. No exceptions for "trivial" changes.
+
 ## Commands
 
 - `npm install`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,68 @@
 ### Features
 
 * integrate release-please for versioning and changelog ([#97](https://github.com/msbfyi/msb-blog/issues/97)) ([d7854fe](https://github.com/msbfyi/msb-blog/commit/d7854fe83a365b1e3f210d08e371f959385a9e48))
+
+## Prior releases
+
+_Everything below predates [release-please](https://github.com/googleapis/release-please), which now generates this file automatically for every release from here on. The old versioning scheme (`paulhatch/semantic-version`) tagged nearly every commit, so only minor/major milestones are summarized here — each links to the full commit range on GitHub._
+
+### [2.0.0](https://github.com/msbfyi/msb-blog/compare/v1.13.0...v2.0.0) (2026-08-21)
+
+- Redesigned site chrome and homepage with the new msb.fyi visual identity: new type system and color tokens, a monogram identity plate, pill nav rail with light/dark/auto mode, and a "dispatch" callout + year-grouped index on the homepage.
+- Dropped the water.css and Font Awesome dependencies in favor of the new design's own tokens.
+- Fixed a build-breaking pagination/static-permalink collision on `/this-week-in-links/`, and stray-markup/missing-description bugs on the podroll and blogroll pages.
+
+### [1.13.0](https://github.com/msbfyi/msb-blog/compare/v1.12.0...v1.13.0) (2026-07-16)
+
+- Added a `/cal` interstitial page with a custom og:image.
+
+### [1.12.0](https://github.com/msbfyi/msb-blog/compare/v1.11.0...v1.12.0) (2026-02-07)
+
+- Migrated Mastodon references from 103.social to social.lol.
+- Replaced the third-party Mastodon archive plugin with a local version with proper error handling.
+
+### [1.11.0](https://github.com/msbfyi/msb-blog/compare/v1.10.0...v1.11.0) (2025-01-16)
+
+- Restored DecapCMS.
+- Added cache-busting for CSS and JS assets.
+
+### [1.10.0](https://github.com/msbfyi/msb-blog/compare/v1.9.0...v1.10.0) (2025-01-07)
+
+- Added `/then` links to previous `/now` pages, and automated `/now`/wishlist updates.
+- New site logos.
+
+### [1.9.0](https://github.com/msbfyi/msb-blog/compare/v1.8.0...v1.9.0) (2024-10-24)
+
+- Added the `fediverse:creator` meta tag.
+- Fixed `/now` archive date bugs.
+
+### [1.8.0](https://github.com/msbfyi/msb-blog/compare/v1.7.0...v1.8.0) (2024-10-21)
+
+- Home and links pages now surface the latest This Week In Links issue.
+
+### [1.7.0](https://github.com/msbfyi/msb-blog/compare/v1.6.0...v1.7.0) (2024-10-21)
+
+- Added a lightbox for images; began migrating toward an eleventy-satisfactory-style config.
+
+### [1.6.0](https://github.com/msbfyi/msb-blog/compare/v1.5.0...v1.6.0) (2024-10-17)
+
+- Documented the (now-retired) versioning convention in the README.
+
+### [1.5.0](https://github.com/msbfyi/msb-blog/compare/v1.4.0...v1.5.0) (2024-10-17)
+
+- Upgraded to Eleventy 3.0.
+
+### [1.4.0](https://github.com/msbfyi/msb-blog/compare/v1.3.0...v1.4.0) (2024-07-05)
+
+- Added Umami analytics (build-time only).
+- Added a Clacks Overhead / GNU Terry Pratchett link to the footer.
+
+### [1.3.0](https://github.com/msbfyi/msb-blog/compare/v1.2.0...v1.3.0) (2024-06-27)
+
+- Added `/chipotle`, `/coffee`, and podroll pages.
+- Added DecapCMS and draft support for posts.
+- Added the Tweet Archive footer link and updated social images.
+
+### [1.2.0](https://github.com/msbfyi/msb-blog/releases/tag/v1.2.0) (2024-04-09)
+
+- Earliest tagged release in this repo's history.


### PR DESCRIPTION
## Summary

Cleans up after last turn's direct push to `main` (which shouldn't have happened) and fixes two changelog issues found by review.

## What changed

- **Restored the "Prior releases" section** (v2.0.0 down to v1.2.0) that got removed — repositioned it *below* release-please's real `2.1.0` entry instead of interleaved with it, so future release-please entries keep inserting cleanly at the top.
- **Fixed a duplicate-header bug** on `/changelog/`: the page template renders its own `<h1>`, and `CHANGELOG.md`'s leading `# Changelog` line was rendering a second one. The `changelog` global data in `.eleventy.js` now strips that line before rendering.
- **Added a "never push directly to main" rule to `AGENTS.md`** — every change goes through a branch + PR from now on, no exceptions for trivial fixes. (This PR follows that rule.)

## Verification

- `APP_VERSION=v2.1.0 npx eleventy` builds clean.
- `/changelog/` renders exactly one `<h1>`, with all 13 historical entries present under "Prior releases" below the real `2.1.0` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)