### PR TITLE
chore: add a "content" commit type for automated content bots

### DIFF
--- a/.github/workflows/generate-link-posts.yml
+++ b/.github/workflows/generate-link-posts.yml
@@ -19,4 +19,4 @@ jobs:
           RAINDROP_COLLECTION_ID: ${{ secrets.RAINDROP_COLLECTION_ID }}
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: Generate weekly link post
+          commit_message: "content: weekly links post"

--- a/.github/workflows/generate-wishlist.yml
+++ b/.github/workflows/generate-wishlist.yml
@@ -20,4 +20,4 @@ jobs:
           RAINDROP_COLLECTION_ID: ${{ secrets.RAINDROP_COLLECTION_ID }}
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: Generate wishlist
+          commit_message: "content: update wishlist"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: stefanzweifel/git-auto-commit-action@v5 
         with:
-          commit_message: Generate wishlist
+          commit_message: "content: update wishlist"
 
       - name: Publish to Cloudflare Pages
        

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,8 +37,14 @@ it just never shows up in a release.
 - `fix: ...` → patch release
 - `feat: ...` → minor release
 - `feat!: ...` or a `BREAKING CHANGE:` footer → major release
-- `docs:`, `chore:`, `refactor:`, `test:`, `ci:`, `build:` → tracked but
-  hidden from the changelog
+- `docs:`, `chore:`, `refactor:`, `test:`, `ci:`, `build:`, `content:` →
+  tracked but hidden from the changelog, no version bump
+
+`content:` is a repo-specific type (not part of the standard set, but
+Conventional Commits allows custom types) for the automated content
+publishing bots — weekly links posts, wishlist regeneration. Use it for
+those, not `chore:`; both are hidden and non-releasing, but `content:`
+keeps automation commits distinguishable from actual maintenance work.
 
 **Do not** use the old `[Breaking]` / `[Feature]` bracket-prefix
 convention — that was `paulhatch/semantic-version`, which this repo no

--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ Commit messages must follow [Conventional Commits](https://www.conventionalcommi
 - `feat: ...` → minor release
 - `feat!: ...` (or a `BREAKING CHANGE:` footer) → major release
 
-On every push to `main`, release-please opens or updates a `chore(main): release X.Y.Z` pull request with the changelog and version bump for whatever's landed. Merging that PR is what actually cuts the release — tags it and updates `CHANGELOG.md`. Other commit types (`docs:`, `chore:`, `refactor:`, `test:`, `ci:`, `build:`) are tracked but hidden from the changelog.
+On every push to `main`, release-please opens or updates a `chore(main): release X.Y.Z` pull request with the changelog and version bump for whatever's landed. Merging that PR is what actually cuts the release — tags it and updates `CHANGELOG.md`. Other commit types (`docs:`, `chore:`, `refactor:`, `test:`, `ci:`, `build:`, `content:`) are tracked but hidden from the changelog. `content:` is used by the automated weekly-links/wishlist bots.
 
 [^1]: Badges from https://badges.pages.dev/

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,6 +13,7 @@
     { "type": "revert", "section": "Reverts" },
     { "type": "docs", "section": "Documentation", "hidden": true },
     { "type": "chore", "section": "Chores", "hidden": true },
+    { "type": "content", "section": "Content", "hidden": true },
     { "type": "refactor", "section": "Code Refactoring", "hidden": true },
     { "type": "test", "section": "Tests", "hidden": true },
     { "type": "ci", "section": "CI", "hidden": true },


### PR DESCRIPTION
## Summary

Conventional Commits doesn't restrict the type token to a fixed set — custom types are spec-compliant as long as they follow `type: description`. This registers `content` with release-please and switches the automated content-publishing commits over to it, instead of relying on bare, unparseable commit messages that happened to be invisible to release-please by accident.

## What changed

- **`release-please-config.json`**: added `{ "type": "content", "section": "Content", "hidden": true }` — same treatment as `chore`/`docs` (tracked, hidden from `CHANGELOG.md`, no version bump).
- **`.github/workflows/generate-link-posts.yml`**, **`generate-wishlist.yml`**, **`publish.yml`**: the three `stefanzweifel/git-auto-commit-action` steps now commit as `content: weekly links post` / `content: update wishlist` instead of bare `Generate weekly link post` / `Generate wishlist`.
- **`AGENTS.md`** / **`README.md`**: documented `content:` alongside the other hidden types, explaining it's for automation bots specifically (not `chore:`, to keep automated commits distinguishable from actual maintenance work in history).

## Why this instead of `chore(content): ...`

Both are equally hidden/non-releasing, but a first-class `content:` type is more explicit and self-documenting than nesting a scope under `chore`, and keeps `git log` easy to scan for "was this a human change or a content bot."

## Verification

- `release-please-config.json` validated as JSON.
- `npx eleventy` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)